### PR TITLE
Updated erroneous roxygen comment in compile_model and amended docs

### DIFF
--- a/R/SimInf_model.R
+++ b/R/SimInf_model.R
@@ -1306,7 +1306,7 @@ contains_C_code <- function(model)
 ##' @param threads Number of threads. Default is NULL, i.e. to use all
 ##'     available processors.
 ##' @param solver Which numerical solver to utilize. Default is 'ssm'.
-##' @return \code{SimInf_model} with result from simulation.
+##' @return \code{SimInf_model} or \code{\link{SimInf_model_dll}} object with result from simulation.
 ##' @references \itemize{
 ##'   \item Bauer P, Engblom S, Widgren S
 ##'   (2016) "Fast Event-Based Epidemiological Simulations on National Scales"

--- a/R/compile_model.R
+++ b/R/compile_model.R
@@ -37,7 +37,6 @@ setClass("SimInf_model_dll",
 )
 
 ##' @rdname run
-##' @value \code{\link{SimInf_model_dll}} with result from simulation.
 ##' @export
 setMethod("run",
           signature(model = "SimInf_model_dll"),

--- a/man/run.Rd
+++ b/man/run.Rd
@@ -24,7 +24,7 @@ available processors.}
 \item{solver}{Which numerical solver to utilize. Default is 'ssm'.}
 }
 \value{
-\code{SimInf_model} with result from simulation.
+\code{SimInf_model} or \code{\link{SimInf_model_dll}} object with result from simulation.
 }
 \description{
 Run the SimInf stochastic simulation algorithm


### PR DESCRIPTION
Hi Stefan,

I spotted a small roxygen typo in the "compile_model()" documentation (I used @value instead of @return). Here is an adjusted amend.

Cheers,

TJ