### PR TITLE
Binomial p

### DIFF
--- a/R/SimInf_events.R
+++ b/R/SimInf_events.R
@@ -60,10 +60,10 @@
 ##'     vector.  n[i] >= 0.
 ##' @slot proportion If \code{n[i]} equals zero, the number of
 ##'     individuals affected by \code{event[i]} is calculated by
-##'     summing the number of individuls ## in the compartments
-##'     determined by \code{select[i]} and multiplying with
-##'     \code{proportion[i]}. Numeric vector.  0 <= proportion[i] <=
-##'     1.
+##'     sampling the number of individuals from a binomial
+##'     distribution using the \code{proportion[i]} and the number of
+##'     individuals in the compartments. Numeric vector.  0 <=
+##'     proportion[i] <= 1.
 ##' @slot select To process \code{event[i]}, the compartments affected
 ##'     by the event are specified with \code{select[i]} together with
 ##'     the matrix \code{E}, where \code{select[i]} determines which
@@ -260,10 +260,11 @@ init_events <- function(events, t0) {
 ##'     The number of individuals affected by the event. n[i] >= 0.
 ##'   }
 ##'   \item{proportion}{
-##'     If \code{n[i]} equals zero, the number of individuals affected by
-##'     \code{event[i]} is calculated by summing the number of individuls
-##      in the compartments determined by \code{select[i]} and multiplying
-##'     with \code{proportion[i]}. 0 <= proportion[i] <= 1.
+##'     If \code{n[i]} equals zero, the number of individuals affected
+##'     by \code{event[i]} is calculated by sampling the number of
+##'     individuals from a binomial distribution using the
+##'     \code{proportion[i]} and the number of individuals in the
+##'     compartments. Numeric vector.  0 <= proportion[i] <= 1.
 ##'   }
 ##'   \item{select}{
 ##'     To process \code{event[i]}, the compartments affected by the

--- a/inst/include/SimInf.h
+++ b/inst/include/SimInf.h
@@ -44,7 +44,8 @@ typedef enum {
     SIMINF_ERR_NODE_OUT_OF_BOUNDS   = -14,
     SIMINF_ERR_EVENTS_N             = -15,
     SIMINF_ERR_EVENT_SHIFT          = -16,
-    SIMINF_ERR_SHIFT_OUT_OF_BOUNDS  = -17
+    SIMINF_ERR_SHIFT_OUT_OF_BOUNDS  = -17,
+    SIMINF_ERR_INVALID_PROPORTION   = -18
 } SimInf_error_code;
 
 /* Forward declaration of the transition rate function. */

--- a/man/SimInf_events-class.Rd
+++ b/man/SimInf_events-class.Rd
@@ -55,10 +55,10 @@ vector.  n[i] >= 0.}
 
 \item{\code{proportion}}{If \code{n[i]} equals zero, the number of
 individuals affected by \code{event[i]} is calculated by
-summing the number of individuls ## in the compartments
-determined by \code{select[i]} and multiplying with
-\code{proportion[i]}. Numeric vector.  0 <= proportion[i] <=
-1.}
+sampling the number of individuals from a binomial
+distribution using the \code{proportion[i]} and the number of
+individuals in the compartments. Numeric vector.  0 <=
+proportion[i] <= 1.}
 
 \item{\code{select}}{To process \code{event[i]}, the compartments affected
 by the event are specified with \code{select[i]} together with

--- a/man/SimInf_events.Rd
+++ b/man/SimInf_events.Rd
@@ -77,9 +77,11 @@ columns:
     The number of individuals affected by the event. n[i] >= 0.
   }
   \item{proportion}{
-    If \code{n[i]} equals zero, the number of individuals affected by
-    \code{event[i]} is calculated by summing the number of individuls
-    with \code{proportion[i]}. 0 <= proportion[i] <= 1.
+    If \code{n[i]} equals zero, the number of individuals affected
+    by \code{event[i]} is calculated by sampling the number of
+    individuals from a binomial distribution using the
+    \code{proportion[i]} and the number of individuals in the
+    compartments. Numeric vector.  0 <= proportion[i] <= 1.
   }
   \item{select}{
     To process \code{event[i]}, the compartments affected by the

--- a/src/SimInf.c
+++ b/src/SimInf.c
@@ -77,6 +77,9 @@ static void SimInf_raise_error(int error)
     case SIMINF_ERR_SHIFT_OUT_OF_BOUNDS:
         Rf_error("'shift' is out of bounds.");
         break;
+    case SIMINF_ERR_INVALID_PROPORTION:
+        Rf_error("Invalid proportion detected (< 0.0 or > 1.0).");
+        break;
     default:
         Rf_error("Unknown error code: %i.", error);
         break;

--- a/src/SimInf.h
+++ b/src/SimInf.h
@@ -44,7 +44,8 @@ typedef enum {
     SIMINF_ERR_NODE_OUT_OF_BOUNDS   = -14,
     SIMINF_ERR_EVENTS_N             = -15,
     SIMINF_ERR_EVENT_SHIFT          = -16,
-    SIMINF_ERR_SHIFT_OUT_OF_BOUNDS  = -17
+    SIMINF_ERR_SHIFT_OUT_OF_BOUNDS  = -17,
+    SIMINF_ERR_INVALID_PROPORTION   = -18
 } SimInf_error_code;
 
 /* Forward declaration of the transition rate function. */

--- a/src/solvers/SimInf_solver.c
+++ b/src/solvers/SimInf_solver.c
@@ -85,7 +85,7 @@ static int SimInf_sample_select(
     /* If n == 0, use the proportion of Nindividuals, else use n as */
     /* the number of individuals to sample                          */
     if (n == 0)
-        n = round(proportion * Nindividuals);
+        n = gsl_ran_binomial(rng, proportion, Nindividuals);
 
     /* Error checking. */
     if (Nstates <= 0 ||     /* No states to sample from, we shouldn't be here. */
@@ -371,11 +371,6 @@ static void SimInf_print_event(
             /* Number of states */
             if ((jcE[e->select + 1] - jcE[e->select]) <= 0)
                 Rprintf("No states to sample from.\n");
-
-            /* If n == 0, use the proportion of Nindividuals, else use
-             * n as the number of individuals to sample */
-            if (n == 0)
-                n = round(e->proportion * Nindividuals);
 
             if (n > Nindividuals)
                 REprintf("Cannot sample %i for event from %i individuals.\n",

--- a/src/solvers/SimInf_solver.c
+++ b/src/solvers/SimInf_solver.c
@@ -83,9 +83,12 @@ static int SimInf_sample_select(
     Nstates = jcE[select + 1] - jcE[select];
 
     /* If n == 0, use the proportion of Nindividuals, else use n as */
-    /* the number of individuals to sample                          */
-    if (n == 0)
+    /* the number of individuals to sample.                         */
+    if (n == 0) {
+        if (proportion < 0 || proportion > 1)
+            return SIMINF_ERR_INVALID_PROPORTION;
         n = gsl_ran_binomial(rng, proportion, Nindividuals);
+    }
 
     /* Error checking. */
     if (Nstates <= 0 ||     /* No states to sample from, we shouldn't be here. */

--- a/tests/sample_select.R
+++ b/tests/sample_select.R
@@ -216,15 +216,14 @@ model <- SISe3(u0        = u0,
 ## Replace proportion = 1 with proportion = 10
 model@events@proportion <- 10
 
-## Check that an animal is moved in this case
-res <- .Call(SimInf:::SISe3_run, model, NULL)@U[1, 2]
-stopifnot(identical(res, 1L))
+res <- assertError(.Call(SimInf:::SISe3_run, model, NULL))
+check_error(res, "Unable to sample individuals for event.")
 
 if (SimInf:::have_openmp()) {
     set_num_threads(2)
-    res <- .Call(SimInf:::SISe3_run, model, NULL)@U[1, 2]
+    res <- assertError(.Call(SimInf:::SISe3_run, model, NULL))
     set_num_threads(1)
-    stopifnot(identical(res, 1L))
+    check_error(res, "Unable to sample individuals for event.")
 }
 
 ## 2 Nodes
@@ -302,15 +301,14 @@ model <- SISe3(u0        = u0,
 ## Replace proportion = 0 with proportion = -1
 model@events@proportion <- -1
 
-res <- .Call(SimInf:::SISe3_run, model, NULL)@U[1, 2]
-## Check that no animal was moved to node one on day 1
-stopifnot(identical(res, 0L))
+res <- assertError(.Call(SimInf:::SISe3_run, model, NULL))
+check_error(res, "Unable to sample individuals for event.")
 
 if (SimInf:::have_openmp()) {
     set_num_threads(2)
-    res <- .Call(SimInf:::SISe3_run, model, NULL)@U[1, 2]
+    res <- assertError(.Call(SimInf:::SISe3_run, model, NULL))
     set_num_threads(1)
-    stopifnot(identical(res, 0L))
+    check_error(res, "Unable to sample individuals for event.")
 }
 
 ## 2 Nodes

--- a/tests/sample_select.R
+++ b/tests/sample_select.R
@@ -217,13 +217,13 @@ model <- SISe3(u0        = u0,
 model@events@proportion <- 10
 
 res <- assertError(.Call(SimInf:::SISe3_run, model, NULL))
-check_error(res, "Unable to sample individuals for event.")
+check_error(res, "Invalid proportion detected (< 0.0 or > 1.0).")
 
 if (SimInf:::have_openmp()) {
     set_num_threads(2)
     res <- assertError(.Call(SimInf:::SISe3_run, model, NULL))
     set_num_threads(1)
-    check_error(res, "Unable to sample individuals for event.")
+    check_error(res, "Invalid proportion detected (< 0.0 or > 1.0).")
 }
 
 ## 2 Nodes
@@ -302,13 +302,13 @@ model <- SISe3(u0        = u0,
 model@events@proportion <- -1
 
 res <- assertError(.Call(SimInf:::SISe3_run, model, NULL))
-check_error(res, "Unable to sample individuals for event.")
+check_error(res, "Invalid proportion detected (< 0.0 or > 1.0).")
 
 if (SimInf:::have_openmp()) {
     set_num_threads(2)
     res <- assertError(.Call(SimInf:::SISe3_run, model, NULL))
     set_num_threads(1)
-    check_error(res, "Unable to sample individuals for event.")
+    check_error(res, "Invalid proportion detected (< 0.0 or > 1.0).")
 }
 
 ## 2 Nodes

--- a/tests/sample_select.R
+++ b/tests/sample_select.R
@@ -216,14 +216,15 @@ model <- SISe3(u0        = u0,
 ## Replace proportion = 1 with proportion = 10
 model@events@proportion <- 10
 
-res <- assertError(.Call(SimInf:::SISe3_run, model, NULL))
-check_error(res, "Unable to sample individuals for event.")
+## Check that an animal is moved in this case
+res <- .Call(SimInf:::SISe3_run, model, NULL)@U[1, 2]
+stopifnot(identical(res, 1L))
 
 if (SimInf:::have_openmp()) {
     set_num_threads(2)
-    res <- assertError(.Call(SimInf:::SISe3_run, model, NULL))
+    res <- .Call(SimInf:::SISe3_run, model, NULL)@U[1, 2]
     set_num_threads(1)
-    check_error(res, "Unable to sample individuals for event.")
+    stopifnot(identical(res, 1L))
 }
 
 ## 2 Nodes
@@ -301,14 +302,15 @@ model <- SISe3(u0        = u0,
 ## Replace proportion = 0 with proportion = -1
 model@events@proportion <- -1
 
-res <- assertError(.Call(SimInf:::SISe3_run, model, NULL))
-check_error(res, "Unable to sample individuals for event.")
+res <- .Call(SimInf:::SISe3_run, model, NULL)@U[1, 2]
+## Check that no animal was moved to node one on day 1
+stopifnot(identical(res, 0L))
 
 if (SimInf:::have_openmp()) {
     set_num_threads(2)
-    res <- assertError(.Call(SimInf:::SISe3_run, model, NULL))
+    res <- .Call(SimInf:::SISe3_run, model, NULL)@U[1, 2]
     set_num_threads(1)
-    check_error(res, "Unable to sample individuals for event.")
+    stopifnot(identical(res, 0L))
 }
 
 ## 2 Nodes

--- a/vignettes/SimInf.Rnw
+++ b/vignettes/SimInf.Rnw
@@ -795,9 +795,9 @@ concentration variable $\Y$.
     \code{proportion} & If \code{n[i]} equals zero, the number of
     individuals affected by \code{event[i]} is calculated by summing
     the number of individuals in the compartments determined by
-    \code{select[i]} and multiplying with \code{proportion[i]}.
-    \code{proportion} is a numeric vector, where $0 \le$
-    \code{proportion[i]} $\le 1$.\\
+    \code{select[i]} and sampling from a binomial distribution with
+    \code{proportion[i]}.  \code{proportion} is a numeric vector,
+    where $0 \le$ \code{proportion[i]} $\le 1$.\\
 
     \code{select} & To process an \code{event[i]}, the compartments
     affected by the event are specified with \code{select[i]} together
@@ -950,23 +950,24 @@ of a scheduled enter event.
 
 The internal transfer event moves \code{n[e]} individuals into new
 compartments within \code{node[e]}.  However, if \code{n[e]} equals
-zero, the number of individuals to move is calculated by multiplying
-the \code{proportion[e]} with the total number of individuals in the
-compartments represented by the non-zero entries in column
-\mbox{\code{E[, s]}}.  The individuals are then proportionally sampled
-and removed from the compartments specified by \code{E[, s]}.  The
-next step is to move the sampled individuals to their new compartment
-using the matrix \code{N} and \code{shift[e]}, where \code{shift[e]}
-specifies which column in \code{N} to use.  Each row $\{1, 2, \ldots,
-\Ncompartments\}$ in \code{N}, represents one compartment in the model
-and the values determine how to move sampled individuals before adding
-them to \code{node[e]} again.  Let \code{q <- shift[e]}, then each
-non-zero entry in \code{N[, q]} defines the number of rows to move
-sampled individuals from that compartment i.e.,~sampled individuals
-from compartment \code{p} are moved to compartment \code{N[p, q] + p},
-where $1 \leq$ \code{N[p, q] + p} $\le \Ncompartments$.  The value of
-\code{dest[e]}, described below, is not used when processing an
-internal transfer event.  See Figure~\ref{fig:internal} in
+zero, the number of individuals to move is calculated by sampling from
+a binomial distribution with \code{proportion[e]} and the total
+number of individuals in the compartments represented by the non-zero
+entries in column \mbox{\code{E[, s]}}.  The individuals are then
+proportionally sampled and removed from the compartments specified by
+\code{E[, s]}.  The next step is to move the sampled individuals to
+their new compartment using the matrix \code{N} and \code{shift[e]},
+where \code{shift[e]} specifies which column in \code{N} to use.  Each
+row $\{1, 2, \ldots, \Ncompartments\}$ in \code{N}, represents one
+compartment in the model and the values determine how to move sampled
+individuals before adding them to \code{node[e]} again.  Let \code{q
+  <- shift[e]}, then each non-zero entry in \code{N[, q]} defines the
+number of rows to move sampled individuals from that compartment
+i.e.,~sampled individuals from compartment \code{p} are moved to
+compartment \code{N[p, q] + p}, where $1 \leq$ \code{N[p, q] + p}
+$\le \Ncompartments$.  The value of \code{dest[e]}, described below,
+is not used when processing an internal transfer event.  See
+Figure~\ref{fig:internal} in
 Appendix~\ref{sec:illustration-scheduled-events} for an illustration
 of a scheduled internal transfer event.
 
@@ -1934,7 +1935,7 @@ legend("topright", c("No vaccination", "Vaccination"),
   \begin{center}
     \includegraphics{img/mparse-epicurve.pdf}
   \end{center}
-  \caption{Comparison beween the number of cases per day of an
+  \caption{Comparison between the number of cases per day of an
     outbreak in an unvaccinated population of cattle herds (black
     solid line) and after vaccination of animals (blue dashed line).
     The vertical line (dotted) indicates when vaccination was


### PR DESCRIPTION
In SimInf the events with n = 0 utilize the proportion instead to calculate the number of animals to move. The number to move was calculated by multiplying the number of individuals in a node by the proportion in the event. This makes it tricky to use proportion for a scheduled event when the proportion is very small or very large and the number of individuals in a pen is small. The result is that you always round to 0 individuals with a small proportion and all individuals with a large proportion. This could result in a bias in the long term mean of the number of individuals moved.

This pull request replaces the multiplication and rounding with a sampling from the binomial to determine the number of individuals to move. The result is that over time you are certain that the number of individuals moved will be consistent with the proportion requested in the event. 